### PR TITLE
ci: add a prettier lint step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ notifications:
 install:
   - yarn install
 script:
+  - yarn lint
   - yarn test --coverage --coverageReporters=text-lcov | coveralls
 before_deploy:
   - yarn build

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"build": "react-scripts build && copyfiles -f production/** build",
 		"test": "react-scripts test",
 		"eject": "react-scripts eject",
+		"lint": "prettier --check \"{src,__{tests,mocks}__}/**/*.jsx\"",
 		"format": "prettier --write \"{src,__{tests,mocks}__}/**/*.jsx\""
 	},
 	"husky": {


### PR DESCRIPTION
Adds a lint step to run prettier's check functionality to check if any of the files that match the glob pattern are up to prettier's standards.