### PR TITLE
fix(form): outbound Mailchimp signup requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"@restart/hooks": "^0.3.12",
 		"formik": "^1.5.7",
+		"jsonp": "^0.2.1",
 		"node-sass": "^4.12.0",
 		"prop-types": "^15.7.2",
 		"react": "^16.9.0",

--- a/src/pages/home/Form.jsx
+++ b/src/pages/home/Form.jsx
@@ -4,6 +4,12 @@ import * as Yup from 'yup';
 import {Formik, Field, ErrorMessage} from 'formik';
 import jsonp from 'jsonp';
 
+const SubmittedMessages = {
+	success: 'Thank you for subscribing!',
+	error: 'An error has occurred. Please reach out to ACM via email to register.',
+	duplicate: 'You are already subscribed. Huzzah!'
+};
+
 const SignUpSchema = Yup.object().shape({
 	EMAIL: Yup.string()
 		.email('Invalid email address')
@@ -20,12 +26,7 @@ const SignUpSchema = Yup.object().shape({
 
 const Signup = () => {
 	const [hasSubmitted, hasSubmittedHandler] = useState(false);
-	const submittedMessages = {
-		success: 'Thank you for subscribing!',
-		error: 'An error has occurred. Please reach out to ACM via email to register.',
-		duplicate: 'You are already subscribed. Huzzah!'
-	};
-	let userMessage = '';
+	const [userMessage, userMessageHandler] = useState('');
 
 	return (
 		<div id="join-acm" className="center-div">
@@ -48,23 +49,19 @@ const Signup = () => {
 						.join('&');
 					const path = `${url}&${data}`;
 					const endpoint = path.replace('/post?', '/post-json?');
-					console.log('posting to the following endpoint: ' + endpoint);
 					/* Post to the survey form */
 					jsonp(endpoint, {param: 'c'}, (err, response) => {
 						if (response.msg.includes('already subscribed')) {
 							/* do something better here */
-							userMessage = submittedMessages.duplicate;
+							userMessageHandler(SubmittedMessages.duplicate);
 						} else if (err) {
-							userMessage = submittedMessages.error;
+							userMessageHandler(SubmittedMessages.error);
 						} else if (response.result !== 'success') {
-							userMessage = submittedMessages.error;
-							console.log(response);
+							userMessageHandler(SubmittedMessages.error);
 						} else {
-							userMessage = submittedMessages.success;
+							userMessageHandler(SubmittedMessages.success);
 						}
 						hasSubmittedHandler(true);
-						// struggling to populate the response message in the form's div
-						console.log('user message is: ' + userMessage);
 					});
 				}}
 			>
@@ -159,7 +156,11 @@ const Signup = () => {
 										/>
 									</div>
 									<div id="mce-responses" className="clear">
-										{hasSubmitted && <div className="response" id="user-response"></div>}
+										{hasSubmitted && (
+											<div className="response" id="user-response">
+												{userMessage}
+											</div>
+										)}
 									</div>
 								</div>
 							</form>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,7 +3259,7 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -6173,6 +6173,13 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  integrity sha1-pltPoPEL2nGaBUQep7lMVfPhW64=
+  dependencies:
+    debug "^2.1.3"
 
 jsprim@^1.2.2:
   version "1.4.1"


### PR DESCRIPTION
This fix borrows some implementation mechanics from a react module;
essentially, the URL endpoint is concatenated by hand and uses jsonp to
submit the form (so that CORS is bypassed).

Fixes #32