### PR TITLE
fix(ci): stop ci/cd tool from spamming chris success comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,12 @@
 			"@semantic-release/commit-analyzer",
 			"@semantic-release/release-notes-generator",
 			"@semantic-release/changelog",
-			"@semantic-release/github",
+			[
+				"@semantic-release/github",
+				{
+					"successComment": false
+				}
+			],
 			[
 				"@qiwi/semantic-release-gh-pages-plugin",
 				{


### PR DESCRIPTION
I... don't know where it went wrong. The repo is just filled with
Chris **success** comments now.

I am so sorry it came to this.

Let's just focus on rebuilding...