### PR TITLE
formspree addition, redirects emails to acm email

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -135,7 +135,7 @@ Author URL: http://w3layouts.com
           <p>Address: 18115 Campus Way NE, Bothell, WA 98011</p>
         </div>
         <h5 class="mt-4">Or send us a message directly:</h5>
-        <form action="your_form_submission_url" method="post"> <!-- We need a formspree here -->
+        <form action="https://formspree.io/f/xjvnnpbd" method="post"> <!-- We need a formspree here -->
           <div class="form-group">
             <label for="fullName">Full Name:</label>
             <input type="text" class="form-control" id="fullName" name="fullName" placeholder="e.g. Steve" required>


### PR DESCRIPTION
Added FormSpree API for e-mail functionality in Contaact Us section
<img width="1421" alt="image" src="https://github.com/UWB-ACM/uwbacm-site/assets/70036749/4693b0b0-f982-47c6-8262-a6af3ddafda4">
<img width="1399" alt="image" src="https://github.com/UWB-ACM/uwbacm-site/assets/70036749/fe99551d-3bb5-4a43-af2c-ca31d74c3162">
